### PR TITLE
fix: seed verifier public coin using result (fib pub input) and context

### DIFF
--- a/recursive/starter/src/fib_winter.rs
+++ b/recursive/starter/src/fib_winter.rs
@@ -11,13 +11,17 @@ use utils::inputs::{FibAirInput, FibRiscInput, Output};
 use winter_air::{Air, FieldExtension, HashFunction, ProofOptions};
 use winter_crypto::hashers::{DefaultSha2, Sha2_256};
 use winter_math::fields::f64::BaseElement;
-use winter_verifier::VerifierChannel;
+use winter_verifier::{Serializable, VerifierChannel};
 
 type E = BaseElement;
 
 pub fn fib_winter() -> Result<()> {
     println!("============================================================");
 
+    // Initialize Risc0 prover
+    let mut prover = Prover::new(&std::fs::read(FIB_VERIFY_PATH).unwrap(), FIB_VERIFY_ID).unwrap();
+
+    // Generate a Fibonacci proof using Winterfell prover
     let e = FibExample::new(1024, get_proof_options());
     let proof = e.prove();
     println!("--------------------------------");
@@ -25,10 +29,7 @@ pub fn fib_winter() -> Result<()> {
     println!("Trace queries length: {}", proof.trace_queries.len());
     verify_with_winter(proof.clone(), e.result.clone());
 
-    let fib_air_input = FibAirInput {
-        trace_info: proof.get_trace_info(),
-        proof_options: proof.options().clone(),
-    };
+    // Expose verification data as public inputs to Risc0 prover
     let air = FibAir::new(proof.get_trace_info(), e.result, proof.options().clone());
     let mut verifier_channel: VerifierChannel<E, Sha2_256<E, DefaultSha2>> =
         VerifierChannel::new::<FibAir>(&air, proof.clone()).map_err(|msg| anyhow!(msg))?;
@@ -40,27 +41,36 @@ pub fn fib_winter() -> Result<()> {
     let constraint_commitment = verifier_channel.read_constraint_commitment().get_raw();
     let (ood_main_trace_frame, ood_aux_trace_frame) = verifier_channel.read_ood_trace_frame();
     let ood_constraint_evaluations = verifier_channel.read_ood_constraint_evaluations();
-    println!("ood size is: {}", ood_main_trace_frame.current.len());
-
-    let risc_inputs = FibRiscInput {
+    let mut proof_context = Vec::new();
+    proof.context.write_into(&mut proof_context);
+    let pub_inputs = FibRiscInput {
         trace_commitments,
         constraint_commitment,
         ood_main_trace_frame,
         ood_aux_trace_frame,
-        result: e.result,
         ood_constraint_evaluations,
+        result: e.result,
+        context: proof_context,
     };
-
-    let mut prover = Prover::new(&std::fs::read(FIB_VERIFY_PATH).unwrap(), FIB_VERIFY_ID).unwrap();
-    let trace_commitments_to_send = rkyv::to_bytes::<_, 256>(&risc_inputs).unwrap();
+    let trace_commitments_to_send = rkyv::to_bytes::<_, 256>(&pub_inputs).unwrap();
     prover.add_input_u8_slice_aux(&trace_commitments_to_send);
+
+    // Expose FibAirInput as public input to Risc0 prover
+    let fib_air_input = FibAirInput {
+        trace_info: proof.get_trace_info(),
+        proof_options: proof.options().clone(),
+    };
     prover
         .add_input(to_vec(&fib_air_input).context("failed to_vec")?.as_slice())
         .context("failed to add input to prover")?;
+
+    // Generate a proof of Winterfell verification using Risc0 prover
     let receipt = prover.run().unwrap();
+    receipt.verify(FIB_VERIFY_ID).unwrap();
+
+    // Debug constraint evaluations
     let result: Output<E> = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
     println!("result is: {:?}", result);
-    receipt.verify(FIB_VERIFY_ID).unwrap();
 
     Ok(())
 }

--- a/recursive/starter/src/main.rs
+++ b/recursive/starter/src/main.rs
@@ -16,141 +16,144 @@ use winter_verifier::VerifierChannel;
 pub mod fib_winter;
 pub mod fibonacci;
 
-fn recursive_miden() -> Result<()> {
-    println!("============================================================");
-
-    let proof_options = get_proof_options();
-
-    // instantiate and prepare the example
-    let example = fibonacci::get_example(1024);
-
-    let fibonacci::Example {
-        program,
-        inputs,
-        num_outputs,
-        pub_inputs,
-        expected_result,
-    } = example;
-    println!("--------------------------------");
-
-    // execute the program and generate the proof of execution
-    let (outputs, proof) = miden::prove(&program, &inputs, num_outputs, &proof_options).unwrap();
-    println!("--------------------------------");
-    println!("Trace length: {}", proof.context.trace_length());
-    println!("Trace queries length: {}", proof.trace_queries.len());
-    println!("Program output: {:?}", outputs);
-    assert_eq!(
-        expected_result, outputs,
-        "Program result was computed incorrectly"
-    );
-
-    let (mut verifier_channel, air_input) =
-        get_verifier_channel(&proof, &outputs, &pub_inputs, program)?;
-    let trace_commitments: Vec<[u8; 32]> = verifier_channel
-        .read_trace_commitments()
-        .into_iter()
-        .map(|x| x.get_raw())
-        .collect();
-    let constraint_commitment = verifier_channel.read_constraint_commitment().get_raw();
-    let (ood_main_trace_frame, ood_aux_trace_frame) = verifier_channel.read_ood_trace_frame();
-    println!("ood size is: {}", ood_main_trace_frame.current.len());
-
-    let risc_inputs = RiscInput {
-        trace_commitments,
-        constraint_commitment,
-        ood_main_trace_frame,
-        ood_aux_trace_frame,
-    };
-
-    let mut prover = Prover::new(&std::fs::read(RECURSIVE_PATH).unwrap(), RECURSIVE_ID).unwrap();
-    let trace_commitments_to_send = rkyv::to_bytes::<_, 256>(&risc_inputs).unwrap();
-    prover.add_input_u8_slice_aux(&trace_commitments_to_send);
-    prover.add_input(to_vec(&air_input)?.as_slice())?;
-    let receipt = prover.run().unwrap();
-    receipt.verify(RECURSIVE_ID).unwrap();
-    Ok(())
-}
-
-fn get_verifier_channel(
-    proof: &StarkProof,
-    outputs: &Vec<u64>,
-    inputs: &Vec<u64>,
-    program: Program,
-) -> Result<(
-    VerifierChannel<BaseElement, Sha2_256<BaseElement, DefaultSha2>>,
-    AirInput,
-)> {
-    let mut stack_input_felts: Vec<Felt> = Vec::with_capacity(inputs.len());
-    for &input in inputs.iter().rev() {
-        stack_input_felts.push(
-            input
-                .try_into()
-                .map_err(|_| anyhow!("cannot map input into felts"))?,
-        );
-    }
-
-    let mut stack_output_felts: Vec<Felt> = Vec::with_capacity(outputs.len());
-    for &output in outputs.iter() {
-        stack_output_felts.push(
-            output
-                .try_into()
-                .map_err(|_| anyhow!("cannot map output into felts"))?,
-        );
-    }
-
-    let pub_inputs = PublicInputs::new(program.hash(), stack_input_felts, stack_output_felts);
-    let air_input = AirInput {
-        trace_info: proof.get_trace_info(),
-        public_inputs: pub_inputs.clone(),
-        proof_options: proof.options().clone(),
-    };
-    let air = ProcessorAir::new(proof.get_trace_info(), pub_inputs, proof.options().clone());
-    Ok((
-        (VerifierChannel::new::<ProcessorAir>(&air, proof.clone()).map_err(|msg| anyhow!(msg))?),
-        air_input,
-    ))
-}
-
-fn sha3() {
-    let mut prover = Prover::new(&std::fs::read(SHA3_PATH).unwrap(), SHA3_ID).unwrap();
-    let input = "my name is cpunkzzz asdfhjklasdf a lot of bytes";
-    prover
-        .add_input(to_vec(&input).unwrap().as_slice())
-        .unwrap();
-    let receipt = prover.run().unwrap();
-    let hashed: String = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
-    println!("I know the preimage of {} and I can prove it!", hashed);
-    receipt.verify(SHA3_ID).unwrap();
-
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(&input);
-    let result = hasher.finalize();
-    let s = hex::encode(&result);
-    assert_eq!(&s, &hashed);
-}
-
-fn exp() {
-    let mut prover = Prover::new(&std::fs::read(EXP_PATH).unwrap(), EXP_ID).unwrap();
-    let base = 16u64;
-    let exp = 10u64;
-    prover.add_input(to_vec(&base).unwrap().as_slice()).unwrap();
-    prover.add_input(to_vec(&exp).unwrap().as_slice()).unwrap();
-    let receipt = prover.run().unwrap();
-    let result: BaseElement = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
-    println!("{}^{} = {}", &base, &exp, &result);
-    receipt.verify(EXP_ID).unwrap();
-    let b = BaseElement::new(base);
-    assert_eq!(result, b.exp(exp));
-}
-
 fn main() -> Result<()> {
+    fib_winter::fib_winter()?;
     // recursive_miden()?;
     // sha3();
-    fib_winter::fib_winter()?;
     // exp();
     Ok(())
 }
 
-pub fn get_proof_options() -> ProofOptions {
-    ProofOptions::with_sha2()
-}
+//#[allow(dead_code)]
+//fn recursive_miden() -> Result<()> {
+//    println!("============================================================");
+//
+//    let proof_options = get_proof_options();
+//
+//    // instantiate and prepare the example
+//    let example = fibonacci::get_example(1024);
+//
+//    let fibonacci::Example {
+//        program,
+//        inputs,
+//        num_outputs,
+//        pub_inputs,
+//        expected_result,
+//    } = example;
+//    println!("--------------------------------");
+//
+//    // execute the program and generate the proof of execution
+//    let (outputs, proof) = miden::prove(&program, &inputs, num_outputs, &proof_options).unwrap();
+//    println!("--------------------------------");
+//    println!("Trace length: {}", proof.context.trace_length());
+//    println!("Trace queries length: {}", proof.trace_queries.len());
+//    println!("Program output: {:?}", outputs);
+//    assert_eq!(
+//        expected_result, outputs,
+//        "Program result was computed incorrectly"
+//    );
+//
+//    let (mut verifier_channel, air_input) =
+//        get_verifier_channel(&proof, &outputs, &pub_inputs, program)?;
+//    let trace_commitments: Vec<[u8; 32]> = verifier_channel
+//        .read_trace_commitments()
+//        .into_iter()
+//        .map(|x| x.get_raw())
+//        .collect();
+//    let constraint_commitment = verifier_channel.read_constraint_commitment().get_raw();
+//    let (ood_main_trace_frame, ood_aux_trace_frame) = verifier_channel.read_ood_trace_frame();
+//    println!("ood size is: {}", ood_main_trace_frame.current.len());
+//
+//    let risc_inputs = RiscInput {
+//        trace_commitments,
+//        constraint_commitment,
+//        ood_main_trace_frame,
+//        ood_aux_trace_frame,
+//    };
+//
+//    let mut prover = Prover::new(&std::fs::read(RECURSIVE_PATH).unwrap(), RECURSIVE_ID).unwrap();
+//    let trace_commitments_to_send = rkyv::to_bytes::<_, 256>(&risc_inputs).unwrap();
+//    prover.add_input_u8_slice_aux(&trace_commitments_to_send);
+//    prover.add_input(to_vec(&air_input)?.as_slice())?;
+//    let receipt = prover.run().unwrap();
+//    receipt.verify(RECURSIVE_ID).unwrap();
+//    Ok(())
+//}
+//
+//fn get_verifier_channel(
+//    proof: &StarkProof,
+//    outputs: &Vec<u64>,
+//    inputs: &Vec<u64>,
+//    program: Program,
+//) -> Result<(
+//    VerifierChannel<BaseElement, Sha2_256<BaseElement, DefaultSha2>>,
+//    AirInput,
+//)> {
+//    let mut stack_input_felts: Vec<Felt> = Vec::with_capacity(inputs.len());
+//    for &input in inputs.iter().rev() {
+//        stack_input_felts.push(
+//            input
+//                .try_into()
+//                .map_err(|_| anyhow!("cannot map input into felts"))?,
+//        );
+//    }
+//
+//    let mut stack_output_felts: Vec<Felt> = Vec::with_capacity(outputs.len());
+//    for &output in outputs.iter() {
+//        stack_output_felts.push(
+//            output
+//                .try_into()
+//                .map_err(|_| anyhow!("cannot map output into felts"))?,
+//        );
+//    }
+//
+//    let pub_inputs = PublicInputs::new(program.hash(), stack_input_felts, stack_output_felts);
+//    let air_input = AirInput {
+//        trace_info: proof.get_trace_info(),
+//        public_inputs: pub_inputs.clone(),
+//        proof_options: proof.options().clone(),
+//    };
+//    let air = ProcessorAir::new(proof.get_trace_info(), pub_inputs, proof.options().clone());
+//    Ok((
+//        (VerifierChannel::new::<ProcessorAir>(&air, proof.clone()).map_err(|msg| anyhow!(msg))?),
+//        air_input,
+//    ))
+//}
+//
+//#[allow(dead_code)]
+//fn sha3() {
+//    let mut prover = Prover::new(&std::fs::read(SHA3_PATH).unwrap(), SHA3_ID).unwrap();
+//    let input = "my name is cpunkzzz asdfhjklasdf a lot of bytes";
+//    prover
+//        .add_input(to_vec(&input).unwrap().as_slice())
+//        .unwrap();
+//    let receipt = prover.run().unwrap();
+//    let hashed: String = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
+//    println!("I know the preimage of {} and I can prove it!", hashed);
+//    receipt.verify(SHA3_ID).unwrap();
+//
+//    let mut hasher = sha2::Sha256::new();
+//    hasher.update(&input);
+//    let result = hasher.finalize();
+//    let s = hex::encode(&result);
+//    assert_eq!(&s, &hashed);
+//}
+//
+//#[allow(dead_code)]
+//fn exp() {
+//    let mut prover = Prover::new(&std::fs::read(EXP_PATH).unwrap(), EXP_ID).unwrap();
+//    let base = 16u64;
+//    let exp = 10u64;
+//    prover.add_input(to_vec(&base).unwrap().as_slice()).unwrap();
+//    prover.add_input(to_vec(&exp).unwrap().as_slice()).unwrap();
+//    let receipt = prover.run().unwrap();
+//    let result: BaseElement = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
+//    println!("{}^{} = {}", &base, &exp, &result);
+//    receipt.verify(EXP_ID).unwrap();
+//    let b = BaseElement::new(base);
+//    assert_eq!(result, b.exp(exp));
+//}
+
+//pub fn get_proof_options() -> ProofOptions {
+//    ProofOptions::with_sha2()
+//}

--- a/recursive/utils/src/fib/example.rs
+++ b/recursive/utils/src/fib/example.rs
@@ -1,7 +1,7 @@
 use winter_air::proof::StarkProof;
 use winter_air::ProofOptions;
 use winter_math::{fields::f64::BaseElement, FieldElement};
-use winter_prover::{Prover, Trace};
+use winter_prover::Prover;
 use winter_verifier::VerifierError;
 
 use super::fib_air::FibAir;
@@ -10,27 +10,17 @@ use super::fib_prover::FibProver;
 pub trait Example {
     fn prove(&self) -> StarkProof;
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError>;
-    fn verify_with_wrong_inputs(&self, proof: StarkProof) -> Result<(), VerifierError>;
 }
 
 impl Example for FibExample {
     fn prove(&self) -> StarkProof {
-        // create a prover
         let prover = FibProver::new(self.options.clone());
-
-        // generate execution trace
         let trace = prover.build_trace(self.sequence_length);
-
-        // generate the proof
         prover.prove(trace).unwrap()
     }
 
     fn verify(&self, proof: StarkProof) -> Result<(), VerifierError> {
         winter_verifier::verify::<FibAir>(proof, self.result)
-    }
-
-    fn verify_with_wrong_inputs(&self, proof: StarkProof) -> Result<(), VerifierError> {
-        todo!()
     }
 }
 

--- a/recursive/utils/src/fib/fib_air.rs
+++ b/recursive/utils/src/fib/fib_air.rs
@@ -10,10 +10,6 @@ use winter_math::{fields::f64::BaseElement, FieldElement};
 
 const TRACE_WIDTH: usize = 2;
 
-pub fn are_equal<E: FieldElement>(a: E, b: E) -> E {
-    a - b
-}
-
 // FIBONACCI AIR
 // ================================================================================================
 
@@ -73,4 +69,8 @@ impl Air for FibAir {
             Assertion::single(1, last_step, self.result),
         ]
     }
+}
+
+pub fn are_equal<E: FieldElement>(a: E, b: E) -> E {
+    a - b
 }

--- a/recursive/utils/src/inputs.rs
+++ b/recursive/utils/src/inputs.rs
@@ -40,6 +40,7 @@ pub struct FibRiscInput<E: FieldElement> {
     pub constraint_commitment: [u8; 32],
     pub ood_main_trace_frame: EvaluationFrame<E>,
     pub ood_aux_trace_frame: Option<EvaluationFrame<E>>,
-    pub result: E,
     pub ood_constraint_evaluations: Vec<E>,
+    pub result: E,
+    pub context: Vec<u8>,
 }


### PR DESCRIPTION
This change fixes the mismatch between `ood_constraint_evaluation_1 ` and `ood_constraint_evaluation_2` in https://github.com/cpunkzzz/risc0-test/pull/6 by seeding the verifiers public coin with the correct inputs.